### PR TITLE
Upgrade to the 4.x release of ulrichsg/getopt-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "php": ">= 7.4",
     "nikic/php-parser": "^4.3",
     "nikic/include-interceptor": "^0.1.1",
-    "ulrichsg/getopt-php": "^3.2"
+    "ulrichsg/getopt-php": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8"


### PR DESCRIPTION
Fixes a bunch of deprecation warnings when running from PHP 8.1

### before

<img width="2672" alt="image" src="https://user-images.githubusercontent.com/133747/183567373-4d713838-f0a5-43bd-a9b4-eb9ff5af5a44.png">

### after

<img width="948" alt="image" src="https://user-images.githubusercontent.com/133747/183567412-42623f80-ced3-4362-95f6-3ff53e9f14d2.png">
