### PR TITLE
Suppress `E_WARNING` triggered by PHP >= 8.5

### DIFF
--- a/src/Mutation/Mutator.php
+++ b/src/Mutation/Mutator.php
@@ -140,7 +140,7 @@ final class Mutator {
             $endPos++;
         }
         // TODO: We won't be able to get large unsigned integers here.
-        $int = (int) \substr($str, $beginPos, $endPos - $beginPos);
+        $int = @(int) \substr($str, $beginPos, $endPos - $beginPos);
         switch ($this->rng->randomInt(4)) {
             case 0:
                 $int++;


### PR DESCRIPTION
PHP 8.5 and higher triggers an `E_WARNING` when the result of `(int)` cannot be represented as an `int`. This warning is intercepted by the library's error handler, which converts it into an `Error` that ultimately aborts the fuzzing process.